### PR TITLE
Changed logic to load assembly with fully qualified name

### DIFF
--- a/lib/CloverConnector/com/clover/remotepay/sdk/CloverConnector.cs
+++ b/lib/CloverConnector/com/clover/remotepay/sdk/CloverConnector.cs
@@ -118,7 +118,7 @@ namespace com.clover.remotepay.sdk
         public CloverConnector(CloverDeviceConfiguration config)
         {
             Config = config;
-            System.Reflection.Assembly assembly = System.Reflection.Assembly.Load("CloverConnector");
+            System.Reflection.Assembly assembly = System.Reflection.Assembly.GetAssembly(GetType());
             SDKInfo.Name = assembly.GetAssemblyAttribute<System.Reflection.AssemblyDescriptionAttribute>().Description;
             SDKInfo.Version = (assembly.GetAssemblyAttribute<System.Reflection.AssemblyFileVersionAttribute>()).Version
                 + (assembly.GetAssemblyAttribute<System.Reflection.AssemblyInformationalVersionAttribute>()).InformationalVersion;


### PR DESCRIPTION
Changed logic to load assembly with fully qualified name instead of partially qualified name.

This should resolve issue when CloverConnector.dll is registered in GAC and there is not physical dll in the path where executing assembly is located.
https://docs.microsoft.com/en-us/archive/msdn-magazine/2009/may/understanding-the-clr-binder